### PR TITLE
#42 - DB에 있는 LocalDate 칼럼 읽어올 때 데이터가 null일 때 예외처리 추가

### DIFF
--- a/src/main/java/com/ncookie/imad/domain/tmdb/service/TmdbService.java
+++ b/src/main/java/com/ncookie/imad/domain/tmdb/service/TmdbService.java
@@ -122,8 +122,8 @@ public class TmdbService {
 
                     .name(tvProgramData.getTranslatedTitle())
                     .originalName(tvProgramData.getOriginalTitle())
-                    .firstAirDate(tvProgramData.getFirstAirDate().toString())
-                    .lastAirDate(tvProgramData.getLastAirDate().toString())
+                    .firstAirDate(getLocalDateString(tvProgramData.getFirstAirDate()))
+                    .lastAirDate(getLocalDateString(tvProgramData.getLastAirDate()))
 
                     .numberOfEpisodes(tvProgramData.getNumberOfEpisodes())
                     .numberOfSeasons(tvProgramData.getNumberOfSeasons())
@@ -166,7 +166,7 @@ public class TmdbService {
                     .title(movieData.getTranslatedTitle())
                     .originalTitle(movieData.getOriginalTitle())
 
-                    .releaseDate(movieData.getReleaseDate().toString())
+                    .releaseDate(getLocalDateString(movieData.getReleaseDate()))
                     .runtime(movieData.getRuntime())
 
                     .credits(DetailsCredits.builder()
@@ -179,7 +179,6 @@ public class TmdbService {
 
         return tmdbDetails;
     }
-
 
     @Transactional
     public TmdbDetails saveContentsDetails(TmdbDetails tmdbDetails, ContentsType type, String certification) {
@@ -321,14 +320,6 @@ public class TmdbService {
     }
 
 
-    private LocalDate parseLocalDate(String date) {
-        if (date == null || date.isEmpty()) {
-            return null;
-        } else {
-            return LocalDate.parse(date);
-        }
-    }
-
     private ContentsType checkAnimationGenre(Set<Integer> genres, ContentsType type) {
         if (genres.contains(16)) {
             return ContentsType.ANIMATION;
@@ -388,5 +379,17 @@ public class TmdbService {
         Set<String> uniqueItems = new LinkedHashSet<>(Arrays.asList(items));  // 중복 제거하면서 순서 유지
 
         return String.join(",", uniqueItems);
+    }
+
+    private LocalDate parseLocalDate(String date) {
+        if (date == null || date.isEmpty()) {
+            return null;
+        } else {
+            return LocalDate.parse(date);
+        }
+    }
+
+    private String getLocalDateString(LocalDate date) {
+        return (date != null) ? date.toString() : "";
     }
 }


### PR DESCRIPTION
- 이전 커밋(8e77479)에서 언급한 내용의 연장성이다. 해당 부분을 제대로 전부 처리하지 못해서 추가로 커밋하게 되었다.
- DB에서 작품 정보를 읽어올 때 LocalDate 변수가 null일 때의 예외처리가 되어있지 않아 발생하는 버그를, 메소드를 추가하여 해결해줬다.