### PR TITLE
#40 - Entity 클래스 중 null 값이 들어갈 수 있는 int 자료형의 타입을 Integer로 수정함

### DIFF
--- a/src/main/java/com/ncookie/imad/domain/contents/entity/MovieData.java
+++ b/src/main/java/com/ncookie/imad/domain/contents/entity/MovieData.java
@@ -19,5 +19,5 @@ public class MovieData extends Contents {
     private LocalDate releaseDate;
 
     @Setter
-    private int runtime;
+    private Integer runtime;
 }

--- a/src/main/java/com/ncookie/imad/domain/contents/entity/TvProgramData.java
+++ b/src/main/java/com/ncookie/imad/domain/contents/entity/TvProgramData.java
@@ -21,8 +21,8 @@ public class TvProgramData extends Contents {
     private LocalDate lastAirDate;
 
     @Setter
-    private int numberOfEpisodes;
+    private Integer numberOfEpisodes;
 
     @Setter
-    private int numberOfSeasons;
+    private Integer numberOfSeasons;
 }


### PR DESCRIPTION
- 외부 API로부터 데이터를 받아오는 경우, 값이 0이 아닌 데이터가 없다는 의미인 null이 들어갈 수도 있다.
  - 이 때 자료형이 primitive type인 int라면 null 값이 들어갔을 때 에러가 발생하므로 wrapper type인 Integer로 변경해주었다.
- 이후 개발 과정에서 null 값이 들어갈 수 있는 필드의 경우, primitive type이라면 wrapper 타입으로 수정해주어야 한다.

This closes #40 