### PR TITLE
#52 - 작품에 하나 밖에 없는 리뷰를 삭제했을 때 정상적으로 수행하지 못하는 버그 해결

### DIFF
--- a/src/main/java/com/ncookie/imad/domain/contents/entity/Contents.java
+++ b/src/main/java/com/ncookie/imad/domain/contents/entity/Contents.java
@@ -65,5 +65,5 @@ public class Contents {
 
     @Setter private int reviewCnt;
     @Setter private int postingCnt;
-    @Setter private float imadScore;
+    @Setter private Float imadScore;
 }

--- a/src/main/java/com/ncookie/imad/domain/tmdb/dto/TmdbDetails.java
+++ b/src/main/java/com/ncookie/imad/domain/tmdb/dto/TmdbDetails.java
@@ -39,7 +39,7 @@ public class TmdbDetails {
     // IMAD Data
     private ContentsType contentsType;
     private int reviewCnt;                          // 리뷰 개수
-    private float imadScore;                        // IMAD 평점 평균
+    private Float imadScore;                        // IMAD 평점 평균
 
 
     // Movie Data


### PR DESCRIPTION
- 리뷰가 추가/수정/삭제 될 때마다 Contents(작품) 테이블의 reviewCnt와 imadScore를 갱신해주는데, score 평균값을 계산하는 메소드에서 리뷰가 존재하지 않으니 null 값이 리턴된다. 그러나 Entity 클래스에서 imadScore는 float 자료형을 사용하기 때문에 에러가 발생한다.
- Entity와 DTO 클래스의 imadScore 변수 타입을 Float으로 수정해주었다.
- 자료형 수정 후 정상동작 확인 완료

This closes #52 