### PR TITLE
#60 - 리뷰 좋아요/싫어요 요청 시 리뷰 마지막 수정 시간도 변경되는 문제 해결

### DIFF
--- a/src/main/java/com/ncookie/imad/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/ncookie/imad/domain/review/repository/ReviewRepository.java
@@ -3,9 +3,11 @@ package com.ncookie.imad.domain.review.repository;
 import com.ncookie.imad.domain.contents.entity.Contents;
 import com.ncookie.imad.domain.review.entity.Review;
 import com.ncookie.imad.domain.user.entity.UserAccount;
+import feign.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
@@ -18,4 +20,12 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     @Query("SELECT COUNT(*) FROM Review WHERE contents = :contents")
     Integer countReviewForContents(Contents contents);
+
+    @Modifying
+    @Query("UPDATE Review SET likeCnt = :likeCnt WHERE reviewId = :reviewId")
+    void updateLikeCount(@Param("reviewId") Long reviewId, @Param("likeCnt") int likeCnt);
+
+    @Modifying
+    @Query("UPDATE Review SET dislikeCnt = :dislikeCnt WHERE reviewId = :reviewId")
+    void updateDislikeCount(@Param("reviewId") Long reviewId, @Param("dislikeCnt") int dislikeCnt);
 }

--- a/src/main/java/com/ncookie/imad/domain/review/service/ReviewService.java
+++ b/src/main/java/com/ncookie/imad/domain/review/service/ReviewService.java
@@ -218,9 +218,8 @@ public class ReviewService {
             }
 
             // like, dislike count 갱신
-            review.setLikeCnt(reviewLikeService.getLikeCount(review));
-            review.setDislikeCnt(reviewLikeService.getDislikeCount(review));
-            reviewRepository.save(review);
+            reviewRepository.updateLikeCount(review.getReviewId(), reviewLikeService.getLikeCount(review));
+            reviewRepository.updateDislikeCount(review.getReviewId(), reviewLikeService.getDislikeCount(review));
         } else {
             throw new BadRequestException(ResponseCode.REVIEW_NOT_FOUND);
         }


### PR DESCRIPTION
- 원래 기획한 의도대라면 리뷰의 제목, 본문, 점수 등이 수정될 때에만 lastModifiedDate 값이 갱신되어야 하는데, 해당 리뷰에 좋아요/싫어요 요청을 날릴 때마다 값이 변경되는 문제가 있었다.
- 리뷰의 좋아요/싫어요 관련 요청을 할 때마다 Review 테이블의 likeCnt, dislikeCnt 값을 갱신해주는데, 이 때 lastModifiedDate 값도 같이 수정되는 것으로 확인되었다.
- 이를 해결하기 위해 save() 메소드 대신 JPQL을 사용하여 likeCnt, dislikeCnt 값을 업데이트하는 쿼리를 사용하도록 하였다.