### PR TITLE
#62 - 유저 선호 장르 TV / MOVIE 구분

### DIFF
--- a/src/main/java/com/ncookie/imad/domain/user/dto/request/UserUpdateRequest.java
+++ b/src/main/java/com/ncookie/imad/domain/user/dto/request/UserUpdateRequest.java
@@ -15,5 +15,6 @@ public class UserUpdateRequest {
     int profileImage;
     String nickname;
 
-    Set<Long> preferredGenres;
+    Set<Long> preferredTvGenres;
+    Set<Long> preferredMovieGenres;
 }

--- a/src/main/java/com/ncookie/imad/domain/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/ncookie/imad/domain/user/dto/response/UserInfoResponse.java
@@ -31,7 +31,8 @@ public class UserInfoResponse {
     // 유저의 추가정보 입력여부를 구분하기 위한 플래그 변수
     private Role role;
 
-    private Set<Long> preferredGenres;
+    private Set<Long> preferredTvGenres;
+    private Set<Long> preferredMovieGenres;
 
 
     public static UserInfoResponse toDTO(UserAccount userAccount) {
@@ -42,7 +43,10 @@ public class UserInfoResponse {
                 .gender(userAccount.getGender())
                 .ageRange(userAccount.getAgeRange())
                 .profileImage(userAccount.getProfileImage())
-                .preferredGenres(userAccount.getPreferredGenres())
+
+                .preferredTvGenres(userAccount.getPreferredTvGenres())
+                .preferredMovieGenres(userAccount.getPreferredMovieGenres())
+
                 .role(userAccount.getRole())
                 .build();
     }

--- a/src/main/java/com/ncookie/imad/domain/user/entity/UserAccount.java
+++ b/src/main/java/com/ncookie/imad/domain/user/entity/UserAccount.java
@@ -44,9 +44,15 @@ public class UserAccount extends BaseTimeEntity {
     // 유저 선호 장르
     @Setter
     @ElementCollection
-    @CollectionTable(name = "preferred_genres", joinColumns = @JoinColumn(name = "user_id", referencedColumnName = "user_id"))
+    @CollectionTable(name = "preferred_tv_genres", joinColumns = @JoinColumn(name = "user_id", referencedColumnName = "user_id"))
     @Builder.Default
-    private Set<Long> preferredGenres = new HashSet<>();
+    private Set<Long> preferredTvGenres = new HashSet<>();
+
+    @Setter
+    @ElementCollection
+    @CollectionTable(name = "preferred_movie_genres", joinColumns = @JoinColumn(name = "user_id", referencedColumnName = "user_id"))
+    @Builder.Default
+    private Set<Long> preferredMovieGenres = new HashSet<>();
 
     private String socialId;            // 로그인한 소셜 타입의 식별자 값 (일반 로그인인 경우 null)
     @Setter private String oauth2AccessToken;   // oauth2 업체와의 연결 해제, 발급받은 토큰 revoke 등을 처리할 때 사용

--- a/src/main/java/com/ncookie/imad/domain/user/service/UserAccountService.java
+++ b/src/main/java/com/ncookie/imad/domain/user/service/UserAccountService.java
@@ -80,7 +80,10 @@ public class UserAccountService {
             user.setAgeRange(userUpdateRequest.getAgeRange());
             user.setGender(userUpdateRequest.getGender());
             user.setProfileImage(userUpdateRequest.getProfileImage());
-            user.setPreferredGenres(userUpdateRequest.getPreferredGenres());
+
+            user.setPreferredTvGenres(userUpdateRequest.getPreferredTvGenres());
+            user.setPreferredMovieGenres(userUpdateRequest.getPreferredMovieGenres());
+
             user.authorizeUser();
 
             userAccountRepository.save(user);


### PR DESCRIPTION
- TMDB에서 분류하는 장르는 TV와 MOVIE가 겹치는 것도 있고, 각자 고유한 경우도 있다. 원래는 이들을 하나의 테이블에서 관리하고 있었는데 클라이언트(iOS) 측의 요청에 따라 TV와 MOVIE의 선호장르를 별도로 관리하기로 하였다.
  - 둘의 장르를 별도로 관리하는 것이 직관적이기도 하고, 나중에 작품 추천을 하게 되었을 때 TV / MOVIE 별로 장르에 따라 추천을 할 수 있을 것으로 보인다.
- User entity 및 DTO 클래스에 TV / MOVIE 별로 선호 장르를 관리하도록 하였다.