### PR TITLE
#74 - 작품 북마크 정보 조회 데이터에서 tmdb id 및 type 삭제

### DIFF
--- a/src/main/java/com/ncookie/imad/domain/profile/dto/BookmarkDetails.java
+++ b/src/main/java/com/ncookie/imad/domain/profile/dto/BookmarkDetails.java
@@ -2,7 +2,6 @@ package com.ncookie.imad.domain.profile.dto;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.ncookie.imad.domain.contents.entity.ContentsType;
 import com.ncookie.imad.domain.profile.entity.ContentsBookmark;
 import lombok.Builder;
 import lombok.Data;
@@ -18,10 +17,8 @@ public class BookmarkDetails {
     private Long userId;
 
     private Long contentsId;
-    private Long contentsTmdbId;            // 작품 TMDB ID
     private String contentsTitle;           // 작품 제목
     private String contentsPosterPath;      // 작품 포스터 이미지 경로
-    private ContentsType contentsType;      // 작품 타입
 
     private LocalDateTime createdDate;
 
@@ -31,10 +28,8 @@ public class BookmarkDetails {
                 .userId(bookmark.getUserAccount().getId())
 
                 .contentsId(bookmark.getContents().getContentsId())
-                .contentsTmdbId(bookmark.getContents().getTmdbId())
                 .contentsTitle(bookmark.getContents().getTranslatedTitle())
                 .contentsPosterPath(bookmark.getContents().getPosterPath())
-                .contentsType(bookmark.getContents().getTmdbType())
 
                 .createdDate(bookmark.getCreatedDate())
                 .build();


### PR DESCRIPTION
- 이제 contents id만 있어도 작품 정보를 조회할 수 있으므로 해당 목적으로 사용되었던 데이터를 DTO 클래스에서 삭제하였음