### PR TITLE
Feature/#78 retrieval service

### DIFF
--- a/src/main/java/com/ncookie/imad/domain/posting/service/CommentService.java
+++ b/src/main/java/com/ncookie/imad/domain/posting/service/CommentService.java
@@ -8,7 +8,7 @@ import com.ncookie.imad.domain.posting.entity.Comment;
 import com.ncookie.imad.domain.posting.entity.Posting;
 import com.ncookie.imad.domain.posting.repository.CommentRepository;
 import com.ncookie.imad.domain.user.entity.UserAccount;
-import com.ncookie.imad.domain.user.service.UserAccountService;
+import com.ncookie.imad.domain.user.service.UserRetrievalService;
 import com.ncookie.imad.global.dto.response.ResponseCode;
 import com.ncookie.imad.global.exception.BadRequestException;
 import jakarta.transaction.Transactional;
@@ -26,12 +26,12 @@ import java.util.Optional;
 public class CommentService {
     private final CommentRepository commentRepository;
 
-    private final UserAccountService userAccountService;
+    private final UserRetrievalService userRetrievalService;
     private final PostingRetrievalService postingRetrievalService;
 
 
     public CommentIdResponse addComment(String accessToken, AddCommentRequest addCommentRequest) {
-        UserAccount user = userAccountService.getUserFromAccessToken(accessToken);
+        UserAccount user = userRetrievalService.getUserFromAccessToken(accessToken);
         Posting posting = postingRetrievalService.getPostingEntityById(addCommentRequest.getPostingId());
 
         Comment comment = commentRepository.save(
@@ -53,7 +53,7 @@ public class CommentService {
     }
 
     public CommentIdResponse modifyComment(String accessToken, Long commentId, ModifyCommentRequest modifyCommentRequest) {
-        UserAccount user = userAccountService.getUserFromAccessToken(accessToken);
+        UserAccount user = userRetrievalService.getUserFromAccessToken(accessToken);
         Optional<Comment> commentOptional = commentRepository.findById(commentId);
 
         if (commentOptional.isPresent()) {
@@ -75,7 +75,7 @@ public class CommentService {
     }
 
     public CommentIdResponse deleteComment(String accessToken, Long commentId) {
-        UserAccount user = userAccountService.getUserFromAccessToken(accessToken);
+        UserAccount user = userRetrievalService.getUserFromAccessToken(accessToken);
         Optional<Comment> commentOptional = commentRepository.findById(commentId);
 
         if (commentOptional.isPresent()) {

--- a/src/main/java/com/ncookie/imad/domain/posting/service/PostingService.java
+++ b/src/main/java/com/ncookie/imad/domain/posting/service/PostingService.java
@@ -10,7 +10,7 @@ import com.ncookie.imad.domain.posting.dto.response.*;
 import com.ncookie.imad.domain.posting.entity.Posting;
 import com.ncookie.imad.domain.posting.repository.PostingRepository;
 import com.ncookie.imad.domain.user.entity.UserAccount;
-import com.ncookie.imad.domain.user.service.UserAccountService;
+import com.ncookie.imad.domain.user.service.UserRetrievalService;
 import com.ncookie.imad.global.dto.response.ResponseCode;
 import com.ncookie.imad.global.exception.BadRequestException;
 import jakarta.transaction.Transactional;
@@ -31,7 +31,7 @@ import java.util.Optional;
 public class PostingService {
     private final PostingRepository postingRepository;
 
-    private final UserAccountService userAccountService;
+    private final UserRetrievalService userRetrievalService;
     private final ContentsService contentsService;
 
     private final PostingLikeService postingLikeService;
@@ -42,7 +42,7 @@ public class PostingService {
 
     public PostingDetailsResponse getPosting(String accessToken, Long postingId) {
         Optional<Posting> optional = postingRepository.findById(postingId);
-        UserAccount user = userAccountService.getUserFromAccessToken(accessToken);
+        UserAccount user = userRetrievalService.getUserFromAccessToken(accessToken);
 
         if (optional.isPresent()) {
             Posting posting = optional.get();
@@ -123,7 +123,7 @@ public class PostingService {
     }
 
     private PostingListResponse getPostingListResponseByPage(String accessToken, Page<Posting> postingPage) {
-        UserAccount user = userAccountService.getUserFromAccessToken(accessToken);
+        UserAccount user = userRetrievalService.getUserFromAccessToken(accessToken);
 
         return PostingListResponse.toDTO(
                 postingPage,
@@ -153,7 +153,7 @@ public class PostingService {
     }
 
     public PostingIdResponse addPosting(String accessToken, AddPostingRequest addPostingRequest) {
-        UserAccount user = userAccountService.getUserFromAccessToken(accessToken);
+        UserAccount user = userRetrievalService.getUserFromAccessToken(accessToken);
         Contents contents = contentsService.getContentsEntityById(addPostingRequest.getContentsId());
 
         Posting posting = postingRepository.save(
@@ -177,7 +177,7 @@ public class PostingService {
 
     public PostingIdResponse modifyPosting(String accessToken, Long postingId, ModifyPostingRequest modifyPostingRequest) {
         Optional<Posting> optional = postingRepository.findById(postingId);
-        UserAccount user = userAccountService.getUserFromAccessToken(accessToken);
+        UserAccount user = userRetrievalService.getUserFromAccessToken(accessToken);
 
         if (optional.isPresent()) {
             Posting posting = optional.get();
@@ -201,7 +201,7 @@ public class PostingService {
 
     public void deletePosting(String accessToken, Long postingId) {
         Optional<Posting> optional = postingRepository.findById(postingId);
-        UserAccount user = userAccountService.getUserFromAccessToken(accessToken);
+        UserAccount user = userRetrievalService.getUserFromAccessToken(accessToken);
 
         if (optional.isPresent()) {
             Posting posting = optional.get();
@@ -222,7 +222,7 @@ public class PostingService {
         }
 
         Optional<Posting> postingOptional = postingRepository.findById(postingId);
-        UserAccount user = userAccountService.getUserFromAccessToken(accessToken);
+        UserAccount user = userRetrievalService.getUserFromAccessToken(accessToken);
 
 
         if (postingOptional.isPresent()) {

--- a/src/main/java/com/ncookie/imad/domain/profile/service/ProfileService.java
+++ b/src/main/java/com/ncookie/imad/domain/profile/service/ProfileService.java
@@ -8,7 +8,7 @@ import com.ncookie.imad.domain.profile.entity.ContentsBookmark;
 import com.ncookie.imad.domain.review.dto.response.ReviewListResponse;
 import com.ncookie.imad.domain.review.service.ReviewService;
 import com.ncookie.imad.domain.user.entity.UserAccount;
-import com.ncookie.imad.domain.user.service.UserAccountService;
+import com.ncookie.imad.domain.user.service.UserRetrievalService;
 import com.ncookie.imad.global.dto.response.ResponseCode;
 import com.ncookie.imad.global.exception.BadRequestException;
 import jakarta.transaction.Transactional;
@@ -24,7 +24,7 @@ import java.util.List;
 @Transactional
 @Service
 public class ProfileService {
-    private final UserAccountService userAccountService;
+    private final UserRetrievalService userRetrievalService;
     private final ContentsService contentsService;
     private final ReviewService reviewService;
 
@@ -33,7 +33,7 @@ public class ProfileService {
     public BookmarkListResponse getContentsBookmarkList(String accessToken, int pageNumber) {
         int REVIEW_LIST_PAGE_SIZE = 10;
         Page<ContentsBookmark> contentsBookmarkPage = bookmarkService.findAllByUserAccount(
-                userAccountService.getUserFromAccessToken(accessToken),
+                userRetrievalService.getUserFromAccessToken(accessToken),
                 PageRequest.of(pageNumber, REVIEW_LIST_PAGE_SIZE)
         );
 
@@ -47,7 +47,7 @@ public class ProfileService {
     
     // 작품 북마크 추가
     public ResponseCode addContentsBookmark(String accessToken, Long contentsId) {
-        UserAccount user = userAccountService.getUserFromAccessToken(accessToken);
+        UserAccount user = userRetrievalService.getUserFromAccessToken(accessToken);
         Contents contents = contentsService.getContentsEntityById(contentsId);
 
         if (!bookmarkService.existsByUserAccountAndContents(user, contents)) {
@@ -66,7 +66,7 @@ public class ProfileService {
 
     // 작품 북마크 삭제
     public void deleteContentsBookmark(String accessToken, Long bookmarkId) {
-        UserAccount user = userAccountService.getUserFromAccessToken(accessToken);
+        UserAccount user = userRetrievalService.getUserFromAccessToken(accessToken);
 
         // 삭제할 데이터가 존재하지 않는 경우
         if (!bookmarkService.existsById(bookmarkId)) {
@@ -76,13 +76,13 @@ public class ProfileService {
     }
 
     public ReviewListResponse getReviewList(String accessToken, int pageNumber) {
-        UserAccount user = userAccountService.getUserFromAccessToken(accessToken);
+        UserAccount user = userRetrievalService.getUserFromAccessToken(accessToken);
 
         return reviewService.getReviewListByUser(user, pageNumber);
     }
 
     public ReviewListResponse getLikedReviewList(String accessToken, int pageNumber) {
-        UserAccount user = userAccountService.getUserFromAccessToken(accessToken);
+        UserAccount user = userRetrievalService.getUserFromAccessToken(accessToken);
 
         return reviewService.getLikedReviewListByUser(user, pageNumber);
     }

--- a/src/main/java/com/ncookie/imad/domain/review/service/ReviewService.java
+++ b/src/main/java/com/ncookie/imad/domain/review/service/ReviewService.java
@@ -12,7 +12,7 @@ import com.ncookie.imad.domain.review.repository.ReviewRepository;
 import com.ncookie.imad.domain.like.entity.ReviewLike;
 import com.ncookie.imad.domain.like.service.ReviewLikeService;
 import com.ncookie.imad.domain.user.entity.UserAccount;
-import com.ncookie.imad.domain.user.service.UserAccountService;
+import com.ncookie.imad.domain.user.service.UserRetrievalService;
 import com.ncookie.imad.global.dto.response.ResponseCode;
 import com.ncookie.imad.global.exception.BadRequestException;
 import jakarta.transaction.Transactional;
@@ -35,7 +35,7 @@ import java.util.Optional;
 public class ReviewService {
     private final ReviewRepository reviewRepository;
 
-    private final UserAccountService userAccountService;
+    private final UserRetrievalService userRetrievalService;
     private final ContentsService contentsService;
 
     private final ReviewLikeService reviewLikeService;
@@ -44,7 +44,7 @@ public class ReviewService {
 
     public ReviewDetailsResponse getReview(String accessToken, Long reviewId) {
         Optional<Review> optional = reviewRepository.findById(reviewId);
-        UserAccount user = userAccountService.getUserFromAccessToken(accessToken);
+        UserAccount user = userRetrievalService.getUserFromAccessToken(accessToken);
 
         if (optional.isPresent()) {
             Review review = optional.get();
@@ -62,7 +62,7 @@ public class ReviewService {
     }
 
     public ReviewListResponse getReviewList(String accessToken, Long contentsId, int pageNumber, String sortString, int order) {
-        UserAccount user = userAccountService.getUserFromAccessToken(accessToken);
+        UserAccount user = userRetrievalService.getUserFromAccessToken(accessToken);
         Contents contents = contentsService.getContentsEntityById(contentsId);
 
         // sort가 null이거나, sort 설정 중 에러가 발생했을 때의 예외처리도 해주어야 함
@@ -137,7 +137,7 @@ public class ReviewService {
     
 
     public AddReviewResponse addReview(String accessToken, AddReviewRequest addReviewRequest) {
-        UserAccount user = userAccountService.getUserFromAccessToken(accessToken);
+        UserAccount user = userRetrievalService.getUserFromAccessToken(accessToken);
         Contents contents = contentsService.getContentsEntityById(addReviewRequest.getContentsId());
 
         // 유저는 작품에 대해 한 가지 리뷰만 작성할 수 있음
@@ -171,7 +171,7 @@ public class ReviewService {
 
     public Long modifyReview(String accessToken, Long reviewId, ModifyReviewRequest reviewRequest) {
         Optional<Review> optional = reviewRepository.findById(reviewId);
-        UserAccount user = userAccountService.getUserFromAccessToken(accessToken);
+        UserAccount user = userRetrievalService.getUserFromAccessToken(accessToken);
 
         if (optional.isPresent()) {
             Review review = optional.get();
@@ -196,7 +196,7 @@ public class ReviewService {
 
     public void deleteReview(String accessToken, Long reviewId) {
         Optional<Review> optional = reviewRepository.findById(reviewId);
-        UserAccount user = userAccountService.getUserFromAccessToken(accessToken);
+        UserAccount user = userRetrievalService.getUserFromAccessToken(accessToken);
 
         if (optional.isPresent()) {
             Review review = optional.get();
@@ -219,7 +219,7 @@ public class ReviewService {
         }
 
         Optional<Review> reviewOptional = reviewRepository.findById(reviewId);
-        UserAccount user = userAccountService.getUserFromAccessToken(accessToken);
+        UserAccount user = userRetrievalService.getUserFromAccessToken(accessToken);
 
         if (reviewOptional.isPresent()) {
             Review review = reviewOptional.get();

--- a/src/main/java/com/ncookie/imad/domain/tmdb/service/TmdbService.java
+++ b/src/main/java/com/ncookie/imad/domain/tmdb/service/TmdbService.java
@@ -21,7 +21,7 @@ import com.ncookie.imad.domain.season.entity.Season;
 import com.ncookie.imad.domain.season.service.SeasonService;
 import com.ncookie.imad.domain.tmdb.dto.*;
 import com.ncookie.imad.domain.user.entity.UserAccount;
-import com.ncookie.imad.domain.user.service.UserAccountService;
+import com.ncookie.imad.domain.user.service.UserRetrievalService;
 import com.ncookie.imad.global.dto.response.ResponseCode;
 import com.ncookie.imad.global.exception.BadRequestException;
 import jakarta.transaction.Transactional;
@@ -54,7 +54,7 @@ public class TmdbService {
 
     private final PersonService personService;
 
-    private final UserAccountService userAccountService;
+    private final UserRetrievalService userRetrievalService;
     private final BookmarkService bookmarkService;
 
     @Transactional
@@ -119,7 +119,7 @@ public class TmdbService {
         // =========================================================================
 
         // bookmark 정보 조회
-        UserAccount user = userAccountService.getUserFromAccessToken(accessToken);
+        UserAccount user = userRetrievalService.getUserFromAccessToken(accessToken);
         ContentsBookmark contentsBookmark = bookmarkService.findByUserAccountAndContents(user, contentsEntity);
 
         Long bookmarkId;

--- a/src/main/java/com/ncookie/imad/domain/user/service/UserAccountService.java
+++ b/src/main/java/com/ncookie/imad/domain/user/service/UserAccountService.java
@@ -135,20 +135,6 @@ public class UserAccountService {
                 .build();
     }
 
-    public UserAccount getUserFromAccessToken(String accessToken) {
-        Optional<String> optionalEmail = jwtService.extractClaimFromJWT(JwtService.CLAIM_EMAIL, extractToken(accessToken));
-        if (optionalEmail.isPresent()) {
-            Optional<UserAccount> optionalUserAccount = userAccountRepository.findByEmail(optionalEmail.get());
-            if (optionalUserAccount.isEmpty()) {
-                throw new BadRequestException(ResponseCode.USER_NOT_FOUND);
-            } else {
-                return optionalUserAccount.get();
-            }
-        } else {
-            return null;
-        }
-    }
-
 
 //    private void saveUserPreferredGenre(UserAccount userAccount, Set<Long> genres) {
 //        for (Long genre : genres) {

--- a/src/main/java/com/ncookie/imad/domain/user/service/UserRetrievalService.java
+++ b/src/main/java/com/ncookie/imad/domain/user/service/UserRetrievalService.java
@@ -1,0 +1,49 @@
+package com.ncookie.imad.domain.user.service;
+
+import com.ncookie.imad.domain.user.entity.UserAccount;
+import com.ncookie.imad.domain.user.repository.UserAccountRepository;
+import com.ncookie.imad.global.dto.response.ResponseCode;
+import com.ncookie.imad.global.exception.BadRequestException;
+import com.ncookie.imad.global.jwt.service.JwtService;
+import jdk.jfr.Description;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static com.ncookie.imad.global.Utils.extractToken;
+
+
+@Description("User entity 조회 용도로만 사용하는 서비스 클래스")
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class UserRetrievalService {
+    private final JwtService jwtService;
+
+    UserAccountRepository userAccountRepository;
+
+
+    @Description("request에 포함된 JWT의 access token으로 UserAccount entity 조회")
+    public UserAccount getUserFromAccessToken(String accessToken) {
+        log.info("액세스 토큰에서 이메일 정보를 추출합니다.");
+        Optional<String> optionalEmail = jwtService.extractClaimFromJWT(JwtService.CLAIM_EMAIL, extractToken(accessToken));
+
+        if (optionalEmail.isPresent()) {
+            Optional<UserAccount> optionalUserAccount = userAccountRepository.findByEmail(optionalEmail.get());
+            if (optionalUserAccount.isEmpty()) {
+                log.error("이메일 정보에 해당하는 유저를 찾을 수 없습니다.");
+                throw new BadRequestException(ResponseCode.USER_NOT_FOUND);
+            } else {
+                log.info("액세스 토큰에서 유저 entity를 얻는데 성공했습니다.");
+                return optionalUserAccount.get();
+            }
+        } else {
+            log.warn("액세스 토큰에서 이메일 정보를 추출하는데 실패했습니다. JWT 토큰이 유효하지 않습니다.");
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
외부 도메인에서 entity 객체를 조회하는 경우가 종종 있는데, 이들 메소드가 구현된 service에서 다른 service를 참조하여 상호참조 문제가 발생할 수 있다.

이를 방지하기 위해 도메인의 entity 조회 기능만을 가지고 있는 전용 service를 생성하고 적용하였다. 이들은 같은 도메인의 repository와 1:1 관계를 맺는다.

This closese #78 