### PR TITLE
#132 - AWS 서버에서 프로그램 구동시키기 위해 임시로 redis 비활성화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 
 	// DB
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	// implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'


### PR DESCRIPTION
- 현재 서버에서 `502 Bad Gateway` 에러가 발생 중이다. redis가 활성화 되어있지만 관련 설정을 yml 파일에서 찾지 못하기 때문에 서버 프로그램이 실행되지 못하고 있는 것으로 추측된다.
- 이를 위해 임시로 redis 의존성을 비활성화 하려고 한다.