### PR TITLE
#132 - Redis `Could not safely identify store assignment for reposito…

### DIFF
--- a/src/main/java/com/ncookie/imad/ImadServerApplication.java
+++ b/src/main/java/com/ncookie/imad/ImadServerApplication.java
@@ -4,9 +4,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @EnableCaching
 @EnableJpaAuditing
+@EnableJpaRepositories(basePackages = "com.ncookie.imad.domain")
 @SpringBootApplication
 public class ImadServerApplication {
 	public static void main(String[] args) {


### PR DESCRIPTION
…ry candidate interface` 에러 해결

- Spring Data Redis가 Spring Data JPA의 repository를 스캔했지만 어느 쪽인지 판단하지 못하여 발생한 에러였다.
- @EnableJpaRepositories 어노테이션 사용하여 해결함